### PR TITLE
Update broken links in get started page

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -18,4 +18,4 @@ Once you've successfully installed Cake Wallet, you can coninue to [Create your 
 
 ## Have fun!
 
-After setup for further guidance, feel free to take a look at the [features](../basic-features/send-funds.md), check out what [cryptocurrencies](../cryptocurrencies/monero.md) we support, or look at the [FAQ](../faq/connection-issues.md).
+After setup for further guidance, feel free to take a look at the [features](../features), check out what [cryptocurrencies](../cryptos) we support, or look at the [FAQ](../faq/connection-issues.md).


### PR DESCRIPTION
updates two broken links in the [Get Started Page](https://docs.cakewallet.com/get-started/)